### PR TITLE
Feat/device list pagination

### DIFF
--- a/cos_registration_server/devices/templates/devices/devices.html
+++ b/cos_registration_server/devices/templates/devices/devices.html
@@ -1,10 +1,27 @@
 {% if devices_list %}
-    <p>Devices list:</p>
+    <p>{{ page_obj.paginator.count }} devices:</p>
     <ul>
     {% for device in devices_list %}
         <li><a href="{% url 'devices:device' device.uid %}">{{ device.uid }}</a></li>
     {% endfor %}
     </ul>
+    <div class="pagination">
+        <span class="step-links">
+            {% if page_obj.has_previous %}
+                <a href="?page=1">&laquo; first</a>
+                <a href="?page={{ page_obj.previous_page_number }}">previous</a>
+            {% endif %}
+    
+            <span class="current">
+                Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.
+            </span>
+    
+            {% if page_obj.has_next %}
+                <a href="?page={{ page_obj.next_page_number }}">next</a>
+                <a href="?page={{ page_obj.paginator.num_pages }}">last &raquo;</a>
+            {% endif %}
+        </span>
+    </div>
 {% else %}
     <p>No devices are available.</p>
 {% endif %}

--- a/cos_registration_server/devices/templates/devices/devices.html
+++ b/cos_registration_server/devices/templates/devices/devices.html
@@ -1,5 +1,5 @@
 {% if devices_list %}
-    <p>{{ page_obj.paginator.count }} devices:</p>
+    <p>{{ page_obj.paginator.count }} device(s):</p>
     <ul>
     {% for device in devices_list %}
         <li><a href="{% url 'devices:device' device.uid %}">{{ device.uid }}</a></li>

--- a/cos_registration_server/devices/views.py
+++ b/cos_registration_server/devices/views.py
@@ -16,6 +16,7 @@ class devices(generic.ListView):  # type: ignore[type-arg]
 
     template_name = "devices/devices.html"
     context_object_name = "devices_list"
+    paginate_by = 25
 
     def get_queryset(self) -> Any:
         """Return all devices on GET."""


### PR DESCRIPTION
Adds a pagination system in the devices list.

It mostly follows the instructions from the official Django documentation: https://docs.djangoproject.com/en/5.1/topics/pagination/