### PR TITLE
fix(devices): test the render of the creation date of the device

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,9 @@ jobs:
       - name: Install project
         run: make install
       - name: Generate django secret key
-        run: echo "SECRET_KEY_DJANGO=$(make secretkey)" >> $GITHUB_ENV
+        run: |
+          GENERATED_SECRET='$(make secretkey)'
+          echo "SECRET_KEY_DJANGO=${GENERATED_SECRET}" >> $GITHUB_ENV
       - name: Run tests
         run: make test
       - name: "Upload coverage to Codecov"

--- a/cos_registration_server/devices/tests.py
+++ b/cos_registration_server/devices/tests.py
@@ -360,10 +360,14 @@ class DeviceViewTests(TestCase):
         url = reverse("devices:device", args=(device.uid,))
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+        formatted_date = device.creation_date.strftime("%B %-d, %Y, %-I:%M %P")
+        formatted_date = formatted_date.replace("am", "a.m.").replace(
+            "pm", "p.m."
+        )
         self.assertContains(
             response,
             f"Device {device.uid} with ip {device.address}, was created on the"
-            f" {device.creation_date.strftime('%b. %-d, %Y, %-I:%M')}",
+            f" {formatted_date}",
         )
         self.assertContains(
             response,


### PR DESCRIPTION
Fix the render of the creation date of the device.

`strftime` and `jinja2` have different format for the dates.