### PR TITLE
Add setting to defined list of csrf trusted origins

### DIFF
--- a/cos_registration_server/cos_registration_server/settings.py
+++ b/cos_registration_server/cos_registration_server/settings.py
@@ -167,3 +167,6 @@ USE_X_FORWARDED_HOST = True
 
 # COS model name used to generate URLs.
 COS_MODEL_NAME = os.getenv("COS_MODEL_NAME", "")
+
+# List of trusted origins for CSRF-protected requests.
+CSRF_TRUSTED_ORIGINS = os.getenv("CSRF_TRUSTED_ORIGINS", "").split(",")


### PR DESCRIPTION
### Summary :memo:

Add dynamic CSRF trusted origins configuration for Django to support HTTPS.

Introduced CSRF_TRUSTED_ORIGINS in settings.py using an environment variable, this ensures Django admin POST requests work correctly over HTTPS.


### Checks
- [ ] Closed #798
- [x] Tested Changes
- [ ] Stakeholder Approval
